### PR TITLE
Fix Android to use _errno, as rustc removed their stub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "errno"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Chris Wong <lambda.fairy@gmail.com>"]
 
 license = "MIT/Apache-2.0"

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -67,9 +67,9 @@ extern {
                link_name = "__error")]
     #[cfg_attr(target_os = "dragonfly",
                link_name = "__dfly_error")]
-    #[cfg_attr(any(target_os = "openbsd", target_os = "bitrig"),
+    #[cfg_attr(any(target_os = "openbsd", target_os = "bitrig", target_os = "android"),
                link_name = "__errno")]
-    #[cfg_attr(any(target_os = "linux", target_os = "android"),
+    #[cfg_attr(target_os = "linux",
                link_name = "__errno_location")]
     fn errno_location() -> *mut c_int;
 


### PR DESCRIPTION
r? @lfairy 

Rust removed the Android binding for `__errno_location` (see: https://github.com/rust-lang/rust/pull/30175/files#diff-cbcfdc29f0353c1a505c3c1980858a09L17, link courtesy of @alexcrichton). I've verified that this new version links correctly on Android and Android-like platforms (e.g. B2G/gonk/FFOS).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lfairy/rust-errno/5)
<!-- Reviewable:end -->
