### PR TITLE
Fix errno on DragonFly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "ntdef", "winbase"] }
 
+[target.'cfg(target_os="dragonfly")'.dependencies]
+errno-dragonfly = "0.1.1"
+
 [badges]
 appveyor = { repository = "lfairy/rust-errno" }
 travis-ci = { repository = "lfairy/rust-errno" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[cfg(unix)] extern crate libc;
 #[cfg(windows)] extern crate winapi;
+#[cfg(target_os = "dragonfly")] extern crate errno_dragonfly;
 
 // FIXME(#10): Rust < 1.11 doesn't support cfg_attr on path
 /*

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -14,6 +14,8 @@
 
 use std::ffi::CStr;
 use libc::{self, c_char, c_int};
+#[cfg(target_os = "dragonfly")]
+use errno_dragonfly::errno_location;
 
 use Errno;
 
@@ -48,12 +50,11 @@ pub fn set_errno(Errno(errno): Errno) {
 }
 
 extern {
+    #[cfg(not(target_os = "dragonfly"))]
     #[cfg_attr(any(target_os = "macos",
                    target_os = "ios",
                    target_os = "freebsd"),
                link_name = "__error")]
-    #[cfg_attr(target_os = "dragonfly",
-               link_name = "__dfly_error")]
     #[cfg_attr(any(target_os = "openbsd", target_os = "bitrig", target_os = "android"),
                link_name = "__errno")]
     #[cfg_attr(target_os = "solaris",


### PR DESCRIPTION
__dfly_error has long been removed from the Rust souce.