### PR TITLE
Fix build on signed char architectures (e.g. aarch64)

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -31,7 +31,8 @@ pub fn with_description<F, T>(err: Errno, callback: F) -> T where
             }
         }
     }
-    let c_str = unsafe { CStr::from_ptr(buf.as_ptr()) };
+    // note: c_char might be signed on some platforms, so the cast to unsigned is required
+    let c_str = unsafe { CStr::from_ptr(buf.as_ptr() as *const u8) };
     callback(Ok(&String::from_utf8_lossy(c_str.to_bytes())))
 }
 


### PR DESCRIPTION
Fixes:

```
error[E0308]: mismatched types
  --> /home/greg/.local/share/cargo/registry/src/github.com-1ecc6299db9ec823/errno-0.2.4/src/unix.rs:34:41
   |
34 |     let c_str = unsafe { CStr::from_ptr(buf.as_ptr()) };
   |                                         ^^^^^^^^^^^^ expected u8, found i8
   |
   = note: expected type `*const u8`
              found type `*const i8`
```