### PR TITLE
WASI errno support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,14 @@ matrix:
     # Add a rule to test the wasm32-wasi target, which is currently only supported
     # with Rust nightly.
     - rust: nightly
-      install: >
+      install:
+        - >
           CARGO_TARGET_DIR=$HOME/wasmtime-target
           cargo install
           --git https://github.com/CraneStation/wasmtime
           --bin wasmtime
           wasmtime
+        - rustup target add wasm32-wasi --toolchain nightly
       script: >
           CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
           cargo test --target wasm32-wasi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - os: osx
       rust: 1.13.0
   include:
+    # Add a rule to test the wasm32-wasi target, which is currently only supported
+    # with Rust nightly.
     - rust: nightly
       install: >
           CARGO_TARGET_DIR=$HOME/wasmtime-target

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
           cargo test --target wasm32-wasi
 script:
   - cargo test
+# Cache the wasmtime-target directory so that we don't rebuild it for each
+# commit.
 cache:
   directories:
     - $HOME/wasmtime-target

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,19 @@ matrix:
     # https://github.com/rust-lang/rust/issues/34674
     - os: osx
       rust: 1.13.0
+  include:
+    - rust: nightly
+      install: >
+          CARGO_TARGET_DIR=$HOME/wasmtime-target
+          cargo install
+          --git https://github.com/CraneStation/wasmtime
+          --bin wasmtime
+          wasmtime
+      script: >
+          CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
+          cargo test --target wasm32-wasi
 script:
   - cargo test
+cache:
+  directories:
+    - $HOME/wasmtime-target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ winapi = { version = "0.3", features = ["errhandlingapi", "minwindef", "ntdef", 
 [target.'cfg(target_os="dragonfly")'.dependencies]
 errno-dragonfly = "0.1.1"
 
+[target.'cfg(target_os="wasi")'.dependencies]
+libc = "0.2"
+
 [badges]
 appveyor = { repository = "lfairy/rust-errno" }
 travis-ci = { repository = "lfairy/rust-errno" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 //! Cross-platform interface to the `errno` variable.
 
+#![cfg_attr(target_os = "wasi", feature(thread_local))]
+
 #[cfg(unix)] extern crate libc;
 #[cfg(windows)] extern crate winapi;
 #[cfg(target_os = "dragonfly")] extern crate errno_dragonfly;
+#[cfg(target_os = "wasi")] extern crate libc;
 
 // FIXME(#10): Rust < 1.11 doesn't support cfg_attr on path
 /*
@@ -15,6 +18,8 @@ mod sys;
 #[cfg(unix)] mod sys { pub use unix::*; }
 #[cfg(windows)] mod windows;
 #[cfg(windows)] mod sys { pub use windows::*; }
+#[cfg(target_os = "wasi")] mod wasi;
+#[cfg(target_os = "wasi")] mod sys { pub use wasi::*; }
 
 use std::fmt;
 use std::io;
@@ -85,6 +90,8 @@ fn it_works() {
 fn check_description() {
     let expect = if cfg!(windows) {
         "Incorrect function."
+    } else if cfg!(target_os = "wasi") {
+        "Argument list too long"
     } else {
         "Operation not permitted"
     };

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -42,6 +42,7 @@ pub fn errno() -> Errno {
 }
 
 pub fn set_errno(Errno(new_errno): Errno) {
+    // libc_errno is thread-local, so simply assign to it.
     unsafe {
         libc_errno = new_errno;
     }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,0 +1,57 @@
+//! Implementation of `errno` functionality for WASI.
+//!
+//! Adapted from `unix.rs`.
+
+// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::ffi::CStr;
+use libc::{self, c_char, c_int};
+
+use Errno;
+
+pub fn with_description<F, T>(err: Errno, callback: F) -> T where
+    F: FnOnce(Result<&str, Errno>) -> T
+{
+    let mut buf = [0 as c_char; 1024];
+    unsafe {
+        if strerror_r(err.0, buf.as_mut_ptr(), buf.len() as libc::size_t) < 0 {
+            let fm_err = errno();
+            if fm_err != Errno(libc::ERANGE) {
+                return callback(Err(fm_err));
+            }
+        }
+    }
+    let c_str = unsafe { CStr::from_ptr(buf.as_ptr()) };
+    callback(Ok(&String::from_utf8_lossy(c_str.to_bytes())))
+}
+
+pub const STRERROR_NAME: &'static str = "strerror_r";
+
+pub fn errno() -> Errno {
+    unsafe {
+        Errno(libc_errno)
+    }
+}
+
+pub fn set_errno(Errno(new_errno): Errno) {
+    unsafe {
+        libc_errno = new_errno;
+    }
+}
+
+extern {
+    #[thread_local]
+    #[link_name = "errno"]
+    static mut libc_errno: c_int;
+
+    fn strerror_r(errnum: c_int, buf: *mut c_char,
+                  buflen: libc::size_t) -> c_int;
+}

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -36,6 +36,7 @@ pub fn with_description<F, T>(err: Errno, callback: F) -> T where
 pub const STRERROR_NAME: &'static str = "strerror_r";
 
 pub fn errno() -> Errno {
+    // libc_errno is thread-local, so simply read its value.
     unsafe {
         Errno(libc_errno)
     }


### PR DESCRIPTION
This adds support for errno on the wasm32-wasi target, which is
currently only supported on Rust nightly.

WASI is a new system-call-like API being designed for WebAssembly; see
[the WASI project page](https://github.com/WebAssembly/WASI) for details.