### PR TITLE
Add NetBSD support

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -55,7 +55,10 @@ extern {
                    target_os = "ios",
                    target_os = "freebsd"),
                link_name = "__error")]
-    #[cfg_attr(any(target_os = "openbsd", target_os = "bitrig", target_os = "android"),
+    #[cfg_attr(any(target_os = "openbsd",
+                   target_os = "netbsd",
+                   target_os = "bitrig",
+                   target_os = "android"),
                link_name = "__errno")]
     #[cfg_attr(target_os = "solaris",
                link_name = "___errno")]


### PR DESCRIPTION
Test result on NetBSD.

```console
$ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running target/debug/deps/errno-92aa8343b3a87dde

running 3 tests
test check_error_into_errno ... ok
test check_description ... ok
test it_works ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests errno

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```