### PR TITLE
Optionally support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,9 @@ libc = "0.2"
 [target.'cfg(target_os="hermit")'.dependencies]
 libc = "0.2"
 
+[features]
+default = ["std"]
+std = []
+
 [badges]
 travis-ci = { repository = "lambda-fairy/rust-errno" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! ```
 
 #![cfg_attr(target_os = "wasi", feature(thread_local))]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(unix)] extern crate libc;
 #[cfg(windows)] extern crate winapi;
@@ -31,8 +32,11 @@
 #[cfg_attr(target_os = "hermit", path = "hermit.rs")]
 mod sys;
 
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(feature = "std")]
 use std::io;
+#[cfg(feature = "std")]
 use std::error::Error;
 
 /// Wraps a platform-specific error code.
@@ -46,6 +50,7 @@ use std::error::Error;
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct Errno(pub i32);
 
+#[cfg(feature = "std")]
 impl fmt::Debug for Errno {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         sys::with_description(*self, |desc| {
@@ -57,6 +62,7 @@ impl fmt::Debug for Errno {
     }
 }
 
+#[cfg(feature = "std")]
 impl fmt::Display for Errno {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         sys::with_description(*self, |desc| match desc {
@@ -74,6 +80,7 @@ impl Into<i32> for Errno {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for Errno {
     // TODO: Remove when MSRV >= 1.27
     #[allow(deprecated)]
@@ -82,6 +89,7 @@ impl Error for Errno {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<Errno> for io::Error {
     fn from(errno: Errno) -> Self {
         io::Error::from_raw_os_error(errno.0)
@@ -102,9 +110,16 @@ pub fn set_errno(err: Errno) {
 fn it_works() {
     let x = errno();
     set_errno(x);
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn it_works_with_to_string() {
+    let x = errno();
     let _ = x.to_string();
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn check_description() {
     let expect = if cfg!(windows) {
@@ -125,6 +140,7 @@ fn check_description() {
         format!("Errno {{ code: 1, description: Some({:?}) }}", expect));
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn check_error_into_errno() {
     const ERROR_CODE: i32 = 1;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -12,13 +12,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "std")]
 use std::ffi::CStr;
-use libc::{self, c_char, c_int};
+use libc::c_int;
+#[cfg(feature = "std")]
+use libc::{self, c_char};
 #[cfg(target_os = "dragonfly")]
 use errno_dragonfly::errno_location;
 
 use Errno;
 
+#[cfg(feature = "std")]
 pub fn with_description<F, T>(err: Errno, callback: F) -> T where
     F: FnOnce(Result<&str, Errno>) -> T
 {
@@ -35,6 +39,7 @@ pub fn with_description<F, T>(err: Errno, callback: F) -> T where
     callback(Ok(&String::from_utf8_lossy(c_str.to_bytes())))
 }
 
+#[cfg(feature = "std")]
 pub const STRERROR_NAME: &'static str = "strerror_r";
 
 pub fn errno() -> Errno {
@@ -67,6 +72,7 @@ extern {
                link_name = "__errno_location")]
     fn errno_location() -> *mut c_int;
 
+    #[cfg(feature = "std")]
     #[cfg_attr(target_os = "linux", link_name = "__xpg_strerror_r")]
     fn strerror_r(errnum: c_int, buf: *mut c_char,
                   buflen: libc::size_t) -> c_int;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -12,11 +12,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "std")]
 use std::ffi::CStr;
-use libc::{self, c_char, c_int};
+use libc::c_int;
+#[cfg(feature = "std")]
+use libc::{self, c_char};
 
 use Errno;
 
+#[cfg(feature = "std")]
 pub fn with_description<F, T>(err: Errno, callback: F) -> T where
     F: FnOnce(Result<&str, Errno>) -> T
 {
@@ -33,6 +37,7 @@ pub fn with_description<F, T>(err: Errno, callback: F) -> T where
     callback(Ok(&String::from_utf8_lossy(c_str.to_bytes())))
 }
 
+#[cfg(feature = "std")]
 pub const STRERROR_NAME: &'static str = "strerror_r";
 
 pub fn errno() -> Errno {
@@ -54,6 +59,7 @@ extern {
     #[link_name = "errno"]
     static mut libc_errno: c_int;
 
+    #[cfg(feature = "std")]
     fn strerror_r(errnum: c_int, buf: *mut c_char,
                   buflen: libc::size_t) -> c_int;
 }


### PR DESCRIPTION
Add a "std" feature which is enabled by default, and enable `no_std`
when it is not enabled. Disable all `Display` and `Debug` features
in `no_std` mode.

My specific use case for this is [rsix](https://crates.io/crates/rsix),
which has a no_std branch, and which uses the `errno` crate in its
`libc`-using backend.

Fixes #18.