### PR TITLE
Silence Clippy incompatible_msrv

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -102,10 +102,10 @@ extern "C" {
     #[cfg_attr(target_os = "nto", link_name = "__get_errno_ptr")]
 
     // Newer libc versions re-export `c_int` from `std` which is incompatible
-    // with Rust < 1.65. However, this is not actually a problem as users can
+    // with Rust < 1.64. However, this is not actually a problem as users can
     // use an older `libc`.
     // See: https://github.com/rust-lang/libc/pull/5015
-    #[allow(clippy::incompatible_msrv)]
+    #[clippy::msrv = "1.64"]
 
     fn errno_location() -> *mut c_int;
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -100,5 +100,12 @@ extern "C" {
     )]
     #[cfg_attr(target_os = "aix", link_name = "_Errno")]
     #[cfg_attr(target_os = "nto", link_name = "__get_errno_ptr")]
+
+    // Newer libc versions re-export `c_int` from `std` which is incompatible
+    // with Rust < 1.65. However, this is not actually a problem as users can
+    // use an older `libc`.
+    // See: https://github.com/rust-lang/libc/pull/5015
+    #[allow(clippy::incompatible_msrv)]
+
     fn errno_location() -> *mut c_int;
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -100,12 +100,10 @@ extern "C" {
     )]
     #[cfg_attr(target_os = "aix", link_name = "_Errno")]
     #[cfg_attr(target_os = "nto", link_name = "__get_errno_ptr")]
-
     // Newer libc versions re-export `c_int` from `std` which is incompatible
     // with Rust < 1.64. However, this is not actually a problem as users can
     // use an older `libc`.
     // See: https://github.com/rust-lang/libc/pull/5015
     #[clippy::msrv = "1.64"]
-
     fn errno_location() -> *mut c_int;
 }


### PR DESCRIPTION
This is due to rust-lang/libc#5015.